### PR TITLE
Improve profile persistence resilience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# espresso
+# Espresso Dial-In Engine
+
+Espresso is a science-driven dial-in assistant that turns a single shot's inputs and taste feedback into causal recommendations. Log a shot, capture the flavour and visual cues, and the heuristic layer will propose the next pull with grind direction, ratio, time, temperature, pre-infusion, and prep focus all tied back to the signals you reported.
+
+## Getting started
+
+1. Serve the static files with any local HTTP server (for example `python -m http.server 8000`).
+2. Open `http://localhost:8000` in your browser.
+3. Record dose, yield, time, temperature, and contextual flags, then submit to generate the diagnosis, target recipe, and presets.
+
+## What the model considers
+
+- **Extraction windows by style** – Normale (≈1:2, 25–30 s) by default, ristretto (1.0–1.7, 22–26 s), and lungo (2.4–3.0, 28–34 s). Milk drinks bias the target toward 1:1.6–1.9 for sweeter, denser shots.
+- **Process-aware biases** – Fermentation-heavy beans (anaerobic, carbonic) cool down automatically while naturals/honey lots open up with slightly higher ratios.
+- **Signal fusion** – Taste descriptors (sour, bitter, astringent, burnt, weak, hollow), visuals (gushing, blonding timing, spritzing), prep flags, and brew ratio/time combine to classify under, over, mixed, or channeling states with a confidence score.
+- **Adjustment magnitudes** – Recommendations include grind direction + magnitude, ratio/yield target, time window, temperature tweaks, pre-infusion length, and prep focus items that mirror barista workflows (WDT, tamp, headspace).
+- **Strength tuning** – If a shot tastes weak but sits inside the extraction window, guidance shifts toward dose or ratio changes instead of more contact time.
+
+## Outputs
+
+- **Diagnosis card** summarises the extraction state, supporting rationale, and risk factors.
+- **Target recipe** delivers the adjusted dose, yield, ratio, time, temperature, grind change, and pre-infusion guidance alongside prep priorities and key next steps.
+- **Testable presets** (Sweet, Balanced, Bright) let you explore adjacent recipes without guesswork.
+- **Bean profiles** persist locally via `localStorage`, enabling quick load/compare flows with no accounts or backend.
+
+Clearing browser storage removes saved profiles.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,818 @@
+const form = document.getElementById("dialForm");
+const sliders = document.querySelectorAll("input[type='range']");
+const diagnosisText = document.getElementById("diagnosisText");
+const confidenceText = document.getElementById("confidenceText");
+const rationaleList = document.getElementById("rationaleList");
+const riskList = document.getElementById("riskList");
+const actionList = document.getElementById("actionList");
+const prepFocusList = document.getElementById("prepFocusList");
+const targetNotes = document.getElementById("targetNotes");
+const targetRecipe = document.getElementById("targetRecipe");
+const presetCards = document.getElementById("presetCards");
+const saveProfileBtn = document.getElementById("saveProfile");
+const clearProfilesBtn = document.getElementById("clearProfiles");
+const profileList = document.getElementById("profileList");
+const compareSelect = document.getElementById("compareSelect");
+const comparison = document.getElementById("comparison");
+
+const STORAGE_KEY = "espresso-profiles";
+
+function generateId() {
+  if (typeof crypto !== "undefined" && crypto.randomUUID) {
+    return crypto.randomUUID();
+  }
+
+  return `profile-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`;
+}
+
+function formatNumber(value, digits = 1) {
+  if (Number.isNaN(value) || value === undefined || value === null) {
+    return "–";
+  }
+  return Number.parseFloat(value).toFixed(digits);
+}
+
+function ratio(dose, yieldOut) {
+  return dose ? yieldOut / dose : 0;
+}
+
+function clamp(value, min, max) {
+  return Math.min(Math.max(value, min), max);
+}
+
+function collectCheckedValues(name) {
+  return Array.from(document.querySelectorAll(`input[name="${name}"]:checked`)).map(
+    (checkbox) => checkbox.value
+  );
+}
+
+function determineBaseTargets(data) {
+  const styles = {
+    ristretto: { ratio: 1.5, ratioRange: [1.2, 1.7], timeRange: [22, 26] },
+    normale: { ratio: 2.0, ratioRange: [1.8, 2.2], timeRange: [25, 30] },
+    lungo: { ratio: 2.7, ratioRange: [2.4, 3.0], timeRange: [28, 34] },
+  };
+
+  const style = styles[data.shotStyle] || styles.normale;
+  const milkRange = [1.6, 1.9];
+  const ratioRange =
+    data.drinkType === "milk"
+      ? [Math.max(milkRange[0], style.ratioRange[0]), Math.min(milkRange[1], style.ratioRange[1])]
+      : style.ratioRange;
+
+  const targetRatio = clamp(style.ratio, ratioRange[0], ratioRange[1]);
+
+  const roastTemps = {
+    light: 94,
+    medium: 93,
+    "medium-dark": 92,
+    dark: 91,
+  };
+
+  const baseTemperature = roastTemps[data.roast] ?? 93;
+
+  return {
+    ratio: targetRatio,
+    ratioRange,
+    timeRange: style.timeRange,
+    temperature: baseTemperature,
+  };
+}
+
+function getProcessAdjustments(process) {
+  switch (process) {
+    case "anaerobic":
+      return {
+        temp: -1.5,
+        ratio: -0.05,
+        note: "Anaerobic lots prefer slightly cooler water to tame fermented acidity.",
+      };
+    case "carbonic":
+      return {
+        temp: -1,
+        ratio: -0.05,
+        note: "Carbonic maceration benefits from a cooler brew to control boozy notes.",
+      };
+    case "natural":
+      return {
+        temp: -0.5,
+        ratio: 0.05,
+        note: "Naturals often open up with a touch more yield or ratio.",
+      };
+    case "honey":
+      return {
+        temp: -0.3,
+        ratio: 0.03,
+        note: "Honey processes like a gentle ratio bump for clarity.",
+      };
+    default:
+      return { temp: 0, ratio: 0, note: "" };
+  }
+}
+
+function evaluateSignals(data, brewRatio, baseTargets) {
+  const signals = {
+    under: [],
+    over: [],
+    channeling: [],
+    strength: [],
+  };
+
+  if (data.time && data.time < baseTargets.timeRange[0]) {
+    signals.under.push(`Shot finished in ${formatNumber(data.time, 0)}s (< ${baseTargets.timeRange[0]}s window).`);
+  }
+
+  if (data.time && data.time > baseTargets.timeRange[1]) {
+    signals.over.push(`Shot ran ${formatNumber(data.time, 0)}s (> ${baseTargets.timeRange[1]}s window).`);
+  }
+
+  if (brewRatio && brewRatio > baseTargets.ratioRange[1] + 0.05) {
+    signals.under.push(
+      `Brew ratio ${formatNumber(brewRatio, 2)} is higher than the target ${formatNumber(baseTargets.ratio, 2)}.`
+    );
+  }
+
+  if (brewRatio && brewRatio < baseTargets.ratioRange[0] - 0.05) {
+    signals.over.push(
+      `Brew ratio ${formatNumber(brewRatio, 2)} is tighter than the style floor ${formatNumber(baseTargets.ratioRange[0], 2)}.`
+    );
+  }
+
+  if (data.tasteFlags.includes("sour")) {
+    signals.under.push("Taste marked sour." );
+  }
+
+  if (data.tasteFlags.includes("weak")) {
+    signals.under.push("Perceived weak body / under-extraction.");
+    if (data.time >= baseTargets.timeRange[0] && data.time <= baseTargets.timeRange[1]) {
+      signals.strength.push("Weak taste despite nominal time — adjust ratio or dose for strength.");
+    }
+  }
+
+  if (data.visualFlags.includes("gushing") || data.visualFlags.includes("blonding_early")) {
+    signals.under.push("Fast flow visuals (gushing / early blonding).");
+  }
+
+  if (
+    data.tasteFlags.some((flag) => ["bitter", "astringent", "burnt"].includes(flag))
+  ) {
+    signals.over.push("Taste flagged bitter/astringent/burnt.");
+  }
+
+  if (data.visualFlags.includes("blonding_late") || data.visualFlags.includes("slow_drip")) {
+    signals.over.push("Late blonding or choking flow indicates over-extraction.");
+  }
+
+  const hasSour = data.tasteFlags.includes("sour");
+  const hasBitter = data.tasteFlags.includes("bitter") || data.tasteFlags.includes("astringent");
+  if (hasSour && hasBitter) {
+    signals.channeling.push("Combined sour and bitter tasting notes (hollow cup).");
+  }
+
+  if (data.tasteFlags.includes("hollow")) {
+    signals.channeling.push("Hollow cup descriptor selected.");
+  }
+
+  if (data.visualFlags.includes("spritzing")) {
+    signals.channeling.push("Spritzing / channeling observed at the spouts.");
+  }
+
+  if (
+    data.prepFlags.some((flag) => ["no_wdt", "uneven_tamp", "overdosed", "screen_imprint"].includes(flag))
+  ) {
+    signals.channeling.push("Prep flag suggests uneven puck resistance.");
+  }
+
+  return signals;
+}
+
+function determineExtractionState(signals) {
+  if (signals.channeling.length) {
+    return "channeling";
+  }
+
+  const hasUnder = signals.under.length > 0;
+  const hasOver = signals.over.length > 0;
+
+  if (hasUnder && hasOver) {
+    return "mixed";
+  }
+
+  if (hasUnder) {
+    return "under";
+  }
+
+  if (hasOver) {
+    return "over";
+  }
+
+  return "balanced";
+}
+
+function computeConfidence(state, signals) {
+  let count = 0;
+  if (state === "under" || state === "over") {
+    count = signals[state].length;
+  } else if (state === "channeling") {
+    count = signals.channeling.length;
+  } else if (state === "mixed") {
+    count = Math.max(signals.under.length, signals.over.length);
+  } else {
+    count = 0;
+  }
+
+  let level = "Low";
+  if (count >= 3) {
+    level = "High";
+  } else if (count === 2) {
+    level = "Medium";
+  } else if (state === "balanced") {
+    level = "Medium";
+  }
+
+  return { level, count };
+}
+
+function buildAdjustments(state, data, brewRatio, baseTargets, processAdjust, signals) {
+  const target = {
+    dose: data.dose,
+    ratio: clamp(brewRatio || baseTargets.ratio, baseTargets.ratioRange[0], baseTargets.ratioRange[1]),
+    time: clamp(data.time || baseTargets.timeRange[1], baseTargets.timeRange[0], baseTargets.timeRange[1]),
+    temperature: clamp(baseTargets.temperature + processAdjust.temp, 88, 97),
+    grind: "Hold grind",
+    preinfusionSeconds: 0,
+    preinfusionText: "0-1 s (skip unless needed)",
+    prepFocus: [],
+    notes: "",
+  };
+
+  const actions = [];
+  const notes = [];
+
+  switch (state) {
+    case "under": {
+      target.grind = "Finer — medium step (≈2-3 clicks / 5-8%)";
+      target.ratio = clamp(
+        brewRatio ? brewRatio - 0.15 : baseTargets.ratio - 0.1,
+        baseTargets.ratioRange[0],
+        baseTargets.ratioRange[1]
+      );
+      target.time = clamp(
+        Math.max(data.time + 3, baseTargets.timeRange[0] + 1),
+        baseTargets.timeRange[0],
+        baseTargets.timeRange[1]
+      );
+      const tempDelta = data.roast === "light" ? 1.5 : 1;
+      target.temperature = clamp(target.temperature + tempDelta, 88, 97);
+      target.preinfusionSeconds = 3;
+      target.preinfusionText = "3 s gentle preinfusion";
+      actions.push("Grind finer by ~2-3 clicks to slow flow.");
+      actions.push(
+        `Aim for ${formatNumber(target.ratio, 2)} : 1 (slightly shorter to concentrate sweetness).`
+      );
+      actions.push(`Let the shot run to about ${formatNumber(target.time, 0)}s.`);
+      notes.push("Slight heat bump helps extract light roasts when under.");
+      break;
+    }
+    case "over": {
+      target.grind = "Coarser — small/medium step (≈1-2 clicks)";
+      target.ratio = clamp(
+        brewRatio ? brewRatio - 0.2 : baseTargets.ratio - 0.15,
+        baseTargets.ratioRange[0],
+        baseTargets.ratioRange[1]
+      );
+      target.time = clamp(
+        Math.max(baseTargets.timeRange[0], (data.time || baseTargets.timeRange[1]) - 3),
+        baseTargets.timeRange[0],
+        baseTargets.timeRange[1]
+      );
+      const tempDelta = data.roast === "dark" || data.roast === "medium-dark" ? -1.5 : -1;
+      target.temperature = clamp(target.temperature + tempDelta, 88, 97);
+      target.preinfusionSeconds = 1;
+      target.preinfusionText = "1 s or straight on";
+      actions.push("Open the grind slightly to cut off bitter tail.");
+      actions.push(
+        `Stop earlier around ${formatNumber(data.dose * target.ratio, 0)}g (${formatNumber(target.ratio, 2)} : 1).`
+      );
+      actions.push(`Keep total time near ${formatNumber(target.time, 0)}s.`);
+      notes.push("Cool the water 1-2°C to smooth harshness.");
+      break;
+    }
+    case "mixed": {
+      target.grind = "Micro-step finer but shorten the shot";
+      target.ratio = clamp(
+        brewRatio ? brewRatio - 0.15 : baseTargets.ratio - 0.1,
+        baseTargets.ratioRange[0],
+        baseTargets.ratioRange[1]
+      );
+      target.time = clamp(
+        Math.max(baseTargets.timeRange[0] + 1, (data.time || baseTargets.timeRange[1]) - 1),
+        baseTargets.timeRange[0],
+        baseTargets.timeRange[1]
+      );
+      const tempDelta = data.roast === "light" ? 0.5 : -0.5;
+      target.temperature = clamp(target.temperature + tempDelta, 88, 97);
+      target.preinfusionSeconds = 3;
+      target.preinfusionText = "3-4 s soak to stabilise flow";
+      target.prepFocus.push("Reinforce prep (WDT, level tamp) before chasing grind.");
+      actions.push("Conflicting signals: tighten prep, then nudge grind finer and cut the shot slightly shorter.");
+      actions.push(`Target roughly ${formatNumber(target.ratio, 2)} : 1 in ${formatNumber(target.time, 0)}s.`);
+      notes.push("Mixed cues — balance grind with improved puck prep.");
+      break;
+    }
+    case "channeling": {
+      target.grind = "Hold grind — fix prep first";
+      target.ratio = clamp(baseTargets.ratio, baseTargets.ratioRange[0], baseTargets.ratioRange[1]);
+      target.time = clamp(
+        Math.max(baseTargets.timeRange[0] + 1, data.time || baseTargets.timeRange[1]),
+        baseTargets.timeRange[0],
+        baseTargets.timeRange[1]
+      );
+      target.preinfusionSeconds = 4;
+      target.preinfusionText = "4 s soft preinfusion";
+      target.prepFocus.push("Thorough WDT / distribution before tamp.");
+      target.prepFocus.push("Level tamp with even pressure.");
+      target.prepFocus.push("Leave ~1 mm headspace; reduce dose if shower screen imprints.");
+      actions.push("Run 4 s low-pressure preinfusion to settle puck.");
+      actions.push("Focus on puck prep before changing grind further.");
+      notes.push("Channeling suspected — keep recipe stable while fixing prep.");
+      break;
+    }
+    case "balanced":
+    default: {
+      target.grind = "Hold grind";
+      target.ratio = clamp(
+        baseTargets.ratio + processAdjust.ratio,
+        baseTargets.ratioRange[0],
+        baseTargets.ratioRange[1]
+      );
+      target.time = clamp(
+        data.time || baseTargets.timeRange[1],
+        baseTargets.timeRange[0],
+        baseTargets.timeRange[1]
+      );
+      target.preinfusionSeconds = 2;
+      target.preinfusionText = "2 s to keep consistency";
+      actions.push("Keep recipe steady and log repeat shots for learning.");
+      break;
+    }
+  }
+
+  if (signals.strength.length) {
+    const strengthRatio = clamp(target.ratio - 0.1, baseTargets.ratioRange[0], baseTargets.ratioRange[1]);
+    actions.push(
+      `Shot tasted weak: either increase dose to ${formatNumber(data.dose + 1, 1)}g (if basket allows) or tighten ratio to ${formatNumber(strengthRatio, 2)} : 1.`
+    );
+    notes.push("Strength tweak recommended while keeping extraction balanced.");
+  }
+
+  if (!target.prepFocus.length) {
+    target.prepFocus.push("WDT or comparable distribution every time.");
+    target.prepFocus.push("Level tamp and confirm headspace before locking in.");
+  }
+
+  target.temperature = clamp(target.temperature, 88, 97);
+  target.ratio = clamp(target.ratio, baseTargets.ratioRange[0], baseTargets.ratioRange[1]);
+  target.time = clamp(target.time, baseTargets.timeRange[0], baseTargets.timeRange[1]);
+  target.yield = Math.round(target.dose * target.ratio);
+  target.notes = notes.filter(Boolean).join(" ");
+
+  return { target, actions };
+}
+
+function computeDiagnosis(data) {
+  const brewRatio = ratio(data.dose, data.yield);
+  const baseTargets = determineBaseTargets(data);
+  const processAdjust = getProcessAdjustments(data.process);
+  const signals = evaluateSignals(data, brewRatio, baseTargets);
+  const extraction = determineExtractionState(signals);
+  const confidence = computeConfidence(extraction, signals);
+  const { target, actions } = buildAdjustments(extraction, data, brewRatio, baseTargets, processAdjust, signals);
+
+  const rationale = new Set();
+  const risks = new Set();
+
+  if (extraction === "balanced") {
+    rationale.add("Inputs sit within the target windows; keep logging for refinement.");
+  } else if (extraction === "mixed") {
+    signals.under.forEach((msg) => rationale.add(msg));
+    signals.over.forEach((msg) => rationale.add(msg));
+    risks.add("Mixed signals — adjust grind carefully and control prep.");
+  } else if (extraction === "channeling") {
+    signals.channeling.forEach((msg) => rationale.add(msg));
+    risks.add("Channeling risk causing uneven extraction.");
+  } else {
+    signals[extraction].forEach((msg) => rationale.add(msg));
+  }
+
+  if (signals.strength.length) {
+    signals.strength.forEach((msg) => rationale.add(msg));
+  }
+
+  if (processAdjust.note) {
+    rationale.add(processAdjust.note);
+  }
+
+  if (signals.channeling.length && extraction !== "channeling") {
+    risks.add("Prep flags indicate potential channeling — monitor puck prep.");
+  }
+
+  const suggestions = Array.from(new Set(actions));
+
+  return {
+    extraction,
+    confidence,
+    rationale: Array.from(rationale),
+    risks: Array.from(risks),
+    actions: suggestions,
+    target,
+    brewRatio,
+    baseTargets,
+  };
+}
+
+function renderDiagnosis(result) {
+  const { extraction, confidence, rationale, risks, actions, target, brewRatio } = result;
+  const labels = {
+    under: "Under-extracted",
+    over: "Over-extracted",
+    balanced: "On target",
+    mixed: "Inconsistent extraction",
+    channeling: "Channeling suspected",
+  };
+
+  diagnosisText.textContent = `${labels[extraction] || "Assessment"} — ratio ${formatNumber(brewRatio, 2)} : 1`;
+  confidenceText.textContent = `Confidence: ${confidence.level}${
+    confidence.count ? ` (${confidence.count} signals)` : ""
+  }`;
+
+  rationaleList.innerHTML = "";
+  if (rationale.length) {
+    rationale.forEach((text) => {
+      const li = document.createElement("li");
+      li.textContent = text;
+      rationaleList.appendChild(li);
+    });
+  }
+
+  riskList.innerHTML = "";
+  if (risks.length) {
+    risks.forEach((text) => {
+      const li = document.createElement("li");
+      li.textContent = text;
+      riskList.appendChild(li);
+    });
+  }
+
+  actionList.innerHTML = "";
+  if (actions.length) {
+    actions.slice(0, 6).forEach((text) => {
+      const li = document.createElement("li");
+      li.textContent = text;
+      actionList.appendChild(li);
+    });
+  }
+
+  prepFocusList.innerHTML = "";
+  target.prepFocus.forEach((text) => {
+    const li = document.createElement("li");
+    li.textContent = text;
+    prepFocusList.appendChild(li);
+  });
+
+  if (target.notes) {
+    targetNotes.textContent = target.notes;
+    targetNotes.classList.remove("hidden");
+  } else {
+    targetNotes.textContent = "";
+    targetNotes.classList.add("hidden");
+  }
+
+  targetRecipe.classList.remove("muted");
+  targetRecipe.innerHTML = `
+    <div><dt>Dose</dt><dd>${formatNumber(target.dose, 1)} g</dd></div>
+    <div><dt>Yield</dt><dd>${formatNumber(target.yield, 0)} g</dd></div>
+    <div><dt>Ratio</dt><dd>${formatNumber(target.ratio, 2)} : 1</dd></div>
+    <div><dt>Time</dt><dd>${formatNumber(target.time, 0)} s</dd></div>
+    <div><dt>Temp</dt><dd>${formatNumber(target.temperature, 0)} °C</dd></div>
+    <div><dt>Grind</dt><dd>${target.grind}</dd></div>
+    <div><dt>Preinfusion</dt><dd>${target.preinfusionText}</dd></div>
+  `;
+}
+
+function generatePresets(data, diagnosis) {
+  const { target, baseTargets } = diagnosis;
+  const baseRatio = target.ratio;
+  const ratioRange = baseTargets.ratioRange;
+  const timeRange = baseTargets.timeRange;
+
+  const sweetRatio = clamp(baseRatio - 0.1, ratioRange[0], ratioRange[1]);
+  const brightRatio = clamp(baseRatio + 0.15, ratioRange[0], ratioRange[1]);
+
+  const presets = [
+    {
+      name: "Sweet",
+      tag: "comfort",
+      ratio: sweetRatio,
+      time: clamp(target.time - 1, timeRange[0], timeRange[1]),
+      temp: clamp(target.temperature + 0.5, 88, 96),
+      preinfusion: target.preinfusionSeconds,
+      notes: "Stop a touch earlier to emphasize sugars.",
+    },
+    {
+      name: "Balanced",
+      tag: "reference",
+      ratio: baseRatio,
+      time: target.time,
+      temp: target.temperature,
+      preinfusion: target.preinfusionSeconds,
+      notes: "Baseline recipe — confirm repeatability.",
+    },
+    {
+      name: "Bright",
+      tag: "explore",
+      ratio: brightRatio,
+      time: clamp(target.time + 2, timeRange[0], timeRange[1] + 1),
+      temp: clamp(target.temperature - 0.5, 88, 96),
+      preinfusion: Math.max(2, target.preinfusionSeconds),
+      notes: "Longer ratio to open acidity and florals.",
+    },
+  ];
+
+  return presets.map((preset) => ({
+    ...preset,
+    dose: data.dose,
+    yield: Math.round(data.dose * preset.ratio),
+  }));
+}
+
+function renderPresets(presets) {
+  presetCards.innerHTML = "";
+  presets.forEach((preset) => {
+    const card = document.createElement("article");
+    card.className = "preset-card";
+    card.innerHTML = `
+      <h4>${preset.name} <small>${preset.tag}</small></h4>
+      <div class="metric-grid">
+        <div><dt>Dose</dt><dd>${formatNumber(preset.dose, 1)} g</dd></div>
+        <div><dt>Yield</dt><dd>${preset.yield} g</dd></div>
+        <div><dt>Ratio</dt><dd>${formatNumber(preset.ratio, 2)} : 1</dd></div>
+        <div><dt>Time</dt><dd>${formatNumber(preset.time, 0)} s</dd></div>
+        <div><dt>Temp</dt><dd>${formatNumber(preset.temp, 1)} °C</dd></div>
+        <div><dt>Preinfusion</dt><dd>${preset.preinfusion ? `${preset.preinfusion}s` : "0-1s"}</dd></div>
+      </div>
+      <p class="muted">${preset.notes}</p>
+    `;
+    presetCards.appendChild(card);
+  });
+}
+
+function readFormData() {
+  const getValue = (id) => document.getElementById(id).value;
+  const getNumber = (id) => Number.parseFloat(getValue(id)) || 0;
+
+  return {
+    bean: getValue("beanName").trim(),
+    process: getValue("process"),
+    roast: getValue("roast"),
+    roastDate: getValue("roastDate"),
+    drinkType: getValue("drinkType"),
+    shotStyle: getValue("shotStyle"),
+    equipment: getValue("equipment"),
+    dose: getNumber("dose"),
+    yield: getNumber("yield"),
+    time: getNumber("time"),
+    temperature: getNumber("temperature") || 93,
+    grind: getValue("grind"),
+    prepNotes: getValue("prepNotes"),
+    sweetness: getNumber("sweetness"),
+    acidity: getNumber("acidity"),
+    bitterness: getNumber("bitterness"),
+    body: getNumber("body"),
+    tasteFlags: collectCheckedValues("tasteFlags"),
+    visualFlags: collectCheckedValues("visualFlags"),
+    prepFlags: collectCheckedValues("prepFlags"),
+    notes: getValue("shotNotes"),
+  };
+}
+
+function handleSubmit(event) {
+  event.preventDefault();
+  const data = readFormData();
+  if (!data.dose || !data.yield || !data.time) {
+    diagnosisText.textContent = "Dose, yield, and time are required to analyze.";
+    return;
+  }
+
+  const result = computeDiagnosis(data);
+  renderDiagnosis(result);
+  const presets = generatePresets(data, result);
+  renderPresets(presets);
+  updateComparison();
+}
+
+function updateSliderValue(slider) {
+  const readout = document.querySelector(`.slider-value[data-for="${slider.id}"]`);
+  if (readout) {
+    readout.textContent = slider.value;
+  }
+}
+
+function loadProfiles() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : [];
+  } catch (error) {
+    console.error("Failed to load profiles", error);
+    return [];
+  }
+}
+
+function saveProfiles(profiles) {
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));
+  } catch (error) {
+    console.error("Failed to persist profiles", error);
+    alert("Couldn't save profiles — browser storage may be full or disabled.");
+  }
+}
+
+function renderProfiles() {
+  const profiles = loadProfiles();
+  profileList.innerHTML = "";
+  compareSelect.innerHTML = '<option value="">Select saved bean</option>';
+
+  if (!profiles.length) {
+    profileList.classList.add("muted");
+    profileList.textContent = "No profiles saved yet.";
+    comparison.textContent = "Pick a bean to compare.";
+    comparison.classList.add("muted");
+    return;
+  }
+
+  profileList.classList.remove("muted");
+  comparison.classList.remove("muted");
+
+  profiles.forEach((profile) => {
+    const card = document.createElement("article");
+    card.className = "profile-card";
+    card.innerHTML = `
+      <header>
+        <h4>${profile.bean}</h4>
+        <time>${new Date(profile.savedAt).toLocaleDateString()}</time>
+      </header>
+      <p class="muted">${profile.process} • ${profile.roast}</p>
+      <p>Target ${formatNumber(profile.target.ratio, 2)} : 1 @ ${formatNumber(
+      profile.target.temperature,
+      0
+    )} °C</p>
+      <button class="secondary" data-load="${profile.id}">Load profile</button>
+      <button class="danger" data-delete="${profile.id}">Delete</button>
+    `;
+    profileList.appendChild(card);
+
+    const option = document.createElement("option");
+    option.value = profile.id;
+    option.textContent = profile.bean;
+    compareSelect.appendChild(option);
+  });
+}
+
+function getProfileById(id) {
+  return loadProfiles().find((profile) => profile.id === id);
+}
+
+function setCheckedValues(name, values = []) {
+  const set = new Set(values);
+  document.querySelectorAll(`input[name="${name}"]`).forEach((checkbox) => {
+    checkbox.checked = set.has(checkbox.value);
+  });
+}
+
+function populateForm(profile) {
+  const shot = profile.lastShot || {};
+  document.getElementById("beanName").value = profile.bean || "";
+  document.getElementById("process").value = profile.process || "washed";
+  document.getElementById("roast").value = profile.roast || "medium";
+  document.getElementById("roastDate").value = profile.roastDate || "";
+  document.getElementById("drinkType").value = shot.drinkType || "straight";
+  document.getElementById("shotStyle").value = shot.shotStyle || "normale";
+  document.getElementById("equipment").value = shot.equipment || "";
+  document.getElementById("dose").value = shot.dose ?? profile.target.dose;
+  document.getElementById("yield").value = shot.yield ?? profile.target.yield;
+  document.getElementById("time").value = shot.time ?? profile.target.time;
+  document.getElementById("temperature").value = shot.temperature ?? profile.target.temperature;
+  document.getElementById("grind").value = shot.grind || profile.target.grind || "";
+  document.getElementById("prepNotes").value = shot.prepNotes || "";
+  document.getElementById("sweetness").value = shot.sweetness ?? 5;
+  document.getElementById("acidity").value = shot.acidity ?? 5;
+  document.getElementById("bitterness").value = shot.bitterness ?? 5;
+  document.getElementById("body").value = shot.body ?? 5;
+  document.getElementById("shotNotes").value = shot.notes || "";
+  setCheckedValues("tasteFlags", shot.tasteFlags || []);
+  setCheckedValues("visualFlags", shot.visualFlags || []);
+  setCheckedValues("prepFlags", shot.prepFlags || []);
+  sliders.forEach(updateSliderValue);
+}
+
+function handleProfileActions(event) {
+  const loadId = event.target.dataset.load;
+  const deleteId = event.target.dataset.delete;
+
+  if (loadId) {
+    const profile = getProfileById(loadId);
+    if (profile) {
+      populateForm(profile);
+      const result = computeDiagnosis(readFormData());
+      renderDiagnosis(result);
+      renderPresets(generatePresets(readFormData(), result));
+    }
+  }
+
+  if (deleteId) {
+    const filtered = loadProfiles().filter((profile) => profile.id !== deleteId);
+    saveProfiles(filtered);
+    renderProfiles();
+    updateComparison();
+  }
+}
+
+function handleSaveProfile() {
+  const data = readFormData();
+  if (!data.bean) {
+    alert("Name the bean before saving.");
+    return;
+  }
+
+  const diagnosis = computeDiagnosis(data);
+  const profiles = loadProfiles();
+  const existing = profiles.find((profile) => profile.bean.toLowerCase() === data.bean.toLowerCase());
+  const profilePayload = {
+    id: existing?.id || generateId(),
+    bean: data.bean,
+    process: data.process,
+    roast: data.roast,
+    roastDate: data.roastDate,
+    target: diagnosis.target,
+    lastShot: data,
+    savedAt: new Date().toISOString(),
+  };
+
+  const updated = existing
+    ? profiles.map((profile) => (profile.id === existing.id ? profilePayload : profile))
+    : [profilePayload, ...profiles];
+
+  saveProfiles(updated);
+  renderProfiles();
+  updateComparison();
+}
+
+function handleClearProfiles() {
+  if (confirm("Delete all saved bean profiles?")) {
+    window.localStorage.removeItem(STORAGE_KEY);
+    renderProfiles();
+    updateComparison();
+  }
+}
+
+function updateComparison() {
+  const current = readFormData();
+  const compareId = compareSelect.value;
+  if (!compareId) {
+    comparison.textContent = "Pick a bean to compare.";
+    comparison.classList.add("muted");
+    return;
+  }
+
+  const profile = getProfileById(compareId);
+  if (!profile) {
+    comparison.textContent = "Profile missing.";
+    comparison.classList.add("muted");
+    return;
+  }
+
+  const currentRatio = ratio(current.dose || profile.target.dose, current.yield || profile.target.yield);
+  const diffRatio = formatNumber(currentRatio - profile.target.ratio, 2);
+  const diffTemp = formatNumber((current.temperature || profile.target.temperature) - profile.target.temperature, 1);
+  const diffTime = formatNumber((current.time || profile.target.time) - profile.target.time, 1);
+
+  comparison.classList.remove("muted");
+  comparison.innerHTML = `
+    <div><strong>${current.bean || "Current shot"}</strong> vs <strong>${profile.bean}</strong></div>
+    <div>Ratio delta: ${diffRatio} vs saved ${formatNumber(profile.target.ratio, 2)} : 1</div>
+    <div>Time delta: ${diffTime}s vs saved ${formatNumber(profile.target.time, 0)}s</div>
+    <div>Temp delta: ${diffTemp}°C vs saved ${formatNumber(profile.target.temperature, 0)}°C</div>
+  `;
+}
+
+form.addEventListener("submit", handleSubmit);
+profileList.addEventListener("click", handleProfileActions);
+saveProfileBtn.addEventListener("click", handleSaveProfile);
+clearProfilesBtn.addEventListener("click", handleClearProfiles);
+compareSelect.addEventListener("change", updateComparison);
+sliders.forEach((slider) => {
+  slider.addEventListener("input", () => updateSliderValue(slider));
+  updateSliderValue(slider);
+});
+
+renderProfiles();

--- a/index.html
+++ b/index.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Espresso Dial-In Engine</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div class="branding">
+        <h1>Espresso</h1>
+        <p class="tagline">Science-driven dial-in intelligence</p>
+      </div>
+      <div class="header-meta">
+        <span class="pill">Auto-dial-in</span>
+        <span class="pill">v0.2</span>
+      </div>
+    </header>
+
+    <main>
+      <section class="panel" aria-labelledby="input-title">
+        <div class="panel-header">
+          <h2 id="input-title">Shot inputs</h2>
+          <p>Capture recipe variables, taste feedback, and prep observations.</p>
+        </div>
+
+        <form id="dialForm" novalidate>
+          <fieldset>
+            <legend>Coffee profile</legend>
+            <div class="field-grid">
+              <label>
+                Bean name
+                <input type="text" id="beanName" placeholder="e.g. Ethiopia Halo" />
+              </label>
+              <label>
+                Process
+                <select id="process">
+                  <option value="washed">Washed</option>
+                  <option value="natural">Natural</option>
+                  <option value="honey">Honey</option>
+                  <option value="anaerobic">Anaerobic</option>
+                  <option value="carbonic">Carbonic maceration</option>
+                </select>
+              </label>
+              <label>
+                Roast level
+                <select id="roast">
+                  <option value="light">Light</option>
+                  <option value="medium" selected>Medium</option>
+                  <option value="medium-dark">Medium-dark</option>
+                  <option value="dark">Dark</option>
+                </select>
+              </label>
+              <label>
+                Roast date
+                <input type="date" id="roastDate" />
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Shot context</legend>
+            <div class="field-grid">
+              <label>
+                Beverage
+                <select id="drinkType">
+                  <option value="straight" selected>Straight espresso</option>
+                  <option value="milk">Milk drink</option>
+                </select>
+              </label>
+              <label>
+                Shot style
+                <select id="shotStyle">
+                  <option value="normale" selected>Normale (≈1:2)</option>
+                  <option value="ristretto">Ristretto (1.0–1.7)</option>
+                  <option value="lungo">Lungo (2.5–3.0)</option>
+                </select>
+              </label>
+              <label>
+                Machine / grinder notes
+                <input type="text" id="equipment" placeholder="e.g. Lelit + Niche" />
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Recipe</legend>
+            <div class="field-grid">
+              <label>
+                Dose (g)
+                <input type="number" id="dose" inputmode="decimal" min="10" max="30" step="0.1" value="18" required />
+              </label>
+              <label>
+                Yield (g)
+                <input type="number" id="yield" inputmode="decimal" min="20" max="70" step="0.1" value="36" required />
+              </label>
+              <label>
+                Shot time (s)
+                <input type="number" id="time" inputmode="decimal" min="10" max="60" step="0.1" value="28" required />
+              </label>
+              <label>
+                Water temp (°C)
+                <input type="number" id="temperature" inputmode="decimal" min="80" max="100" step="0.1" value="93" />
+              </label>
+              <label>
+                Grind setting
+                <input type="text" id="grind" placeholder="e.g. 5.2 on Niche" />
+              </label>
+              <label>
+                Prep notes
+                <input type="text" id="prepNotes" placeholder="WDT + level tamp" />
+              </label>
+            </div>
+          </fieldset>
+
+          <fieldset>
+            <legend>Taste snapshot</legend>
+            <p class="help-text">Drag the sliders and mark the descriptors that matched the cup.</p>
+            <div class="slider-grid">
+              <div class="slider">
+                <label for="sweetness">Sweetness</label>
+                <input type="range" id="sweetness" min="0" max="10" value="5" />
+                <span class="slider-value" data-for="sweetness">5</span>
+              </div>
+              <div class="slider">
+                <label for="acidity">Acidity</label>
+                <input type="range" id="acidity" min="0" max="10" value="5" />
+                <span class="slider-value" data-for="acidity">5</span>
+              </div>
+              <div class="slider">
+                <label for="bitterness">Bitterness</label>
+                <input type="range" id="bitterness" min="0" max="10" value="5" />
+                <span class="slider-value" data-for="bitterness">5</span>
+              </div>
+              <div class="slider">
+                <label for="body">Body / texture</label>
+                <input type="range" id="body" min="0" max="10" value="5" />
+                <span class="slider-value" data-for="body">5</span>
+              </div>
+            </div>
+
+            <div class="chip-field">
+              <p class="chip-label">Taste descriptors</p>
+              <div class="chip-group" role="group" aria-label="Taste descriptors">
+                <label class="chip">
+                  <input type="checkbox" name="tasteFlags" value="sour" />
+                  <span>Sour</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="tasteFlags" value="bitter" />
+                  <span>Bitter</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="tasteFlags" value="astringent" />
+                  <span>Astringent</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="tasteFlags" value="burnt" />
+                  <span>Burnt</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="tasteFlags" value="weak" />
+                  <span>Weak / thin</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="tasteFlags" value="hollow" />
+                  <span>Hollow (sour + bitter)</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="chip-field">
+              <p class="chip-label">Visual cues</p>
+              <div class="chip-group" role="group" aria-label="Visual cues">
+                <label class="chip">
+                  <input type="checkbox" name="visualFlags" value="gushing" />
+                  <span>Gushing start</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="visualFlags" value="blonding_early" />
+                  <span>Blonding early</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="visualFlags" value="blonding_late" />
+                  <span>Blonding very late</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="visualFlags" value="slow_drip" />
+                  <span>Slow drip / choke</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="visualFlags" value="spritzing" />
+                  <span>Spritzing / channeling</span>
+                </label>
+              </div>
+            </div>
+
+            <div class="chip-field">
+              <p class="chip-label">Prep flags</p>
+              <div class="chip-group" role="group" aria-label="Prep flags">
+                <label class="chip">
+                  <input type="checkbox" name="prepFlags" value="no_wdt" />
+                  <span>No WDT / distribution</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="prepFlags" value="uneven_tamp" />
+                  <span>Uneven tamp</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="prepFlags" value="overdosed" />
+                  <span>Overdosed basket</span>
+                </label>
+                <label class="chip">
+                  <input type="checkbox" name="prepFlags" value="screen_imprint" />
+                  <span>Screen imprint</span>
+                </label>
+              </div>
+            </div>
+          </fieldset>
+
+          <label class="notes-field">
+            Additional shot notes
+            <textarea id="shotNotes" rows="3" placeholder="e.g. fast first drip, slight spritzing"></textarea>
+          </label>
+
+          <button type="submit" class="primary">Diagnose shot</button>
+        </form>
+      </section>
+
+      <section class="panel results" aria-labelledby="results-title">
+        <div class="panel-header">
+          <h2 id="results-title">Diagnosis &amp; target</h2>
+          <p>Actionable adjustments grounded in the heuristics.</p>
+        </div>
+        <div class="results-grid">
+          <article class="result-card" id="diagnosisCard">
+            <h3>Diagnosis</h3>
+            <p id="diagnosisText" class="muted">Log a shot to see insights.</p>
+            <p id="confidenceText" class="muted"></p>
+            <h4 class="subheading">Rationale</h4>
+            <ul id="rationaleList" class="bullet-list"></ul>
+            <h4 class="subheading">Risks</h4>
+            <ul id="riskList" class="bullet-list"></ul>
+          </article>
+          <article class="result-card" id="targetCard">
+            <h3>Target recipe</h3>
+            <dl id="targetRecipe" class="metric-grid muted">
+              <div><dt>Dose</dt><dd>–</dd></div>
+              <div><dt>Yield</dt><dd>–</dd></div>
+              <div><dt>Ratio</dt><dd>–</dd></div>
+              <div><dt>Time</dt><dd>–</dd></div>
+              <div><dt>Temp</dt><dd>–</dd></div>
+              <div><dt>Grind</dt><dd>–</dd></div>
+              <div><dt>Preinfusion</dt><dd>–</dd></div>
+            </dl>
+            <h4 class="subheading">Prep focus</h4>
+            <ul id="prepFocusList" class="bullet-list"></ul>
+            <p id="targetNotes" class="muted hidden"></p>
+            <h4 class="subheading">Next actions</h4>
+            <ul id="actionList" class="action-list"></ul>
+          </article>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="presets-title">
+        <div class="panel-header">
+          <h2 id="presets-title">Testable presets</h2>
+          <p>Three quick explorations per bean.</p>
+        </div>
+        <div id="presetCards" class="preset-grid">
+          <p class="muted">Run a diagnosis to generate presets.</p>
+        </div>
+      </section>
+
+      <section class="panel" aria-labelledby="profiles-title">
+        <div class="panel-header">
+          <h2 id="profiles-title">Bean profiles</h2>
+          <p>Save, load, and compare dial-ins. Stored locally.</p>
+        </div>
+        <div class="profile-actions">
+          <button id="saveProfile" class="secondary">Save current bean</button>
+          <button id="clearProfiles" class="danger" type="button">Clear all</button>
+        </div>
+        <div class="profiles-layout">
+          <div>
+            <h3 class="subheading">Saved beans</h3>
+            <div id="profileList" class="profile-list muted">No profiles saved yet.</div>
+          </div>
+          <div>
+            <h3 class="subheading">Quick compare</h3>
+            <label class="compare-select">
+              Against
+              <select id="compareSelect">
+                <option value="">Select saved bean</option>
+              </select>
+            </label>
+            <div id="comparison" class="comparison muted">Pick a bean to compare.</div>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        Built for baristas dialing-in faster. Feedback makes it smarter — log each
+        shot and refine.
+      </p>
+    </footer>
+
+    <script src="app.js" defer></script>
+  </body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,507 @@
+:root {
+  color-scheme: light;
+  --bg: #0b0d10;
+  --surface: rgba(20, 24, 31, 0.72);
+  --surface-alt: rgba(32, 38, 48, 0.65);
+  --border: rgba(255, 255, 255, 0.08);
+  --accent: #f97316;
+  --accent-soft: rgba(249, 115, 22, 0.18);
+  --text: #f5f5f7;
+  --text-muted: rgba(245, 245, 247, 0.65);
+  --success: #34d399;
+  --danger: #f87171;
+  --font-body: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  font-family: var(--font-body);
+  background: radial-gradient(circle at top, rgba(57, 70, 97, 0.4), transparent 55%),
+    linear-gradient(160deg, #050608, #10131a 50%, #050608 100%);
+  color: var(--text);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+}
+
+main {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: 2rem 1rem 4rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.app-header,
+.app-footer {
+  width: min(1200px, 100%);
+  margin: 0 auto;
+  padding: 1.5rem 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.app-footer {
+  justify-content: center;
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.branding h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.5rem);
+  font-weight: 700;
+}
+
+.branding .tagline {
+  margin: 0.2rem 0 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+.header-meta {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.3rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  backdrop-filter: blur(14px);
+  box-shadow: 0 20px 45px rgba(5, 8, 13, 0.55);
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+}
+
+.panel-header p {
+  margin: 0.35rem 0 1.5rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+}
+
+fieldset {
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  margin-bottom: 1rem;
+  background: rgba(12, 15, 21, 0.55);
+}
+
+legend {
+  padding: 0 0.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  gap: 0.35rem;
+}
+
+input,
+select,
+textarea {
+  appearance: none;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.7rem 0.85rem;
+  background: rgba(18, 22, 29, 0.85);
+  color: var(--text);
+  font-family: inherit;
+  font-size: 0.95rem;
+}
+
+input:focus,
+select:focus,
+textarea:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+textarea {
+  resize: vertical;
+  min-height: 5rem;
+}
+
+.help-text {
+  margin: 0 0 1rem;
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.slider-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.slider {
+  background: rgba(26, 30, 38, 0.7);
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+}
+
+.slider label {
+  font-weight: 600;
+  font-size: 0.9rem;
+}
+
+.slider input[type="range"] {
+  width: 100%;
+  accent-color: var(--accent);
+}
+
+.slider-value {
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.notes-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  font-size: 0.9rem;
+}
+
+.primary,
+.secondary,
+.danger {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.5rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+.primary {
+  background: linear-gradient(135deg, #f97316, #f59e0b);
+  color: #0b0d10;
+  width: 100%;
+  margin-top: 0.5rem;
+}
+
+.primary:hover,
+.secondary:hover,
+.danger:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 12px 25px rgba(0, 0, 0, 0.25);
+}
+
+.secondary {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--text);
+}
+
+.danger {
+  background: rgba(248, 113, 113, 0.18);
+  color: #fecaca;
+}
+
+.results-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.result-card {
+  background: var(--surface-alt);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid var(--border);
+}
+
+.result-card h3 {
+  margin: 0 0 0.75rem;
+}
+
+.subheading {
+  margin: 1.25rem 0 0.4rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.muted {
+  color: var(--text-muted);
+}
+
+.hidden {
+  display: none;
+}
+
+.bullet-list,
+.action-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.bullet-list li,
+.action-list li {
+  padding-left: 1.25rem;
+  position: relative;
+  font-size: 0.9rem;
+}
+
+.bullet-list li::before {
+  content: "•";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+
+.action-list li::before {
+  content: "→";
+  position: absolute;
+  left: 0;
+  color: var(--accent);
+}
+
+.metric-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+  font-size: 0.9rem;
+}
+
+.metric-grid div {
+  background: rgba(12, 15, 21, 0.6);
+  border: 1px solid var(--border);
+  padding: 0.8rem;
+  border-radius: 1rem;
+}
+
+.metric-grid dt {
+  margin: 0 0 0.35rem;
+  font-weight: 600;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.metric-grid dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.preset-grid {
+  display: grid;
+  gap: 1rem;
+}
+
+.preset-card {
+  background: rgba(26, 30, 38, 0.75);
+  border: 1px solid var(--border);
+  border-radius: 1.25rem;
+  padding: 1.25rem;
+}
+
+.preset-card h4 {
+  margin: 0 0 0.75rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.preset-card h4 small {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+  background: rgba(255, 255, 255, 0.08);
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+}
+
+.profile-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+}
+
+.profile-list {
+  display: grid;
+  gap: 1rem;
+}
+
+.profile-card {
+  background: rgba(26, 30, 38, 0.7);
+  padding: 1rem;
+  border-radius: 1rem;
+  border: 1px solid var(--border);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.profile-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.profile-card h4 {
+  margin: 0;
+}
+
+.profile-card time {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.profile-card button {
+  width: fit-content;
+}
+
+.profiles-layout {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.compare-select {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  font-size: 0.9rem;
+}
+
+.comparison {
+  margin-top: 0.75rem;
+  background: rgba(26, 30, 38, 0.7);
+  border: 1px solid var(--border);
+  border-radius: 1rem;
+  padding: 1rem;
+  font-size: 0.9rem;
+  display: grid;
+  gap: 0.25rem;
+}
+
+.chip-field {
+  margin-top: 1.25rem;
+}
+
+.chip-label {
+  margin: 0 0 0.5rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.chip-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.chip {
+  position: relative;
+}
+
+.chip input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.chip span {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: rgba(26, 30, 38, 0.65);
+  font-size: 0.85rem;
+  transition: background 0.15s ease, border-color 0.15s ease, transform 0.15s ease;
+}
+
+.chip input:checked + span {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--text);
+  transform: translateY(-1px);
+}
+
+@media (min-width: 640px) {
+  .field-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .slider-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .results-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .preset-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .profiles-layout {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (min-width: 960px) {
+  main {
+    padding: 3rem 0 4rem;
+    gap: 2rem;
+  }
+
+  .panel {
+    padding: 2rem;
+  }
+
+  .panel-header h2 {
+    font-size: 1.45rem;
+  }
+}


### PR DESCRIPTION
## Summary
- add a random id helper so profile saves work even when `crypto.randomUUID` is unavailable
- guard localStorage writes and surface an alert if profiles cannot be persisted

## Testing
- no automated tests (static site)

------
https://chatgpt.com/codex/tasks/task_e_68da4c2addfc832f9407e1719c738aa3